### PR TITLE
Use keys.openpgp.org keyserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The file into which the `borgmatic` output will be logged.
 ### Installation-related
 
 ```
-backup_borg_keyserver: hkp://p80.pool.sks-keyservers.net:80
+backup_borg_keyserver: hkps://keys.openpgp.org
 ```
 The GPG keyserver from which to download the `borg` public key.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ backup_log_file: /var/log/borgmatic.log
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-backup_borg_keyserver: hkp://p80.pool.sks-keyservers.net:80
+backup_borg_keyserver: hkps://keys.openpgp.org
 backup_borg_gpg_fpr: 6D5BEF9ADD2075805747B70F9F88FB52FAF7B393
 backup_borg_url: https://github.com/borgbackup/borg/releases/download
 backup_borg_asset: borg-linux{{ ansible_architecture [-2:] }}

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_borg_installed(host):
     cmd = host.run('/usr/local/bin/borg --version')
-    assert cmd.stdout == 'borg 1.1.7\n'
+    assert cmd.stdout == 'borg 1.1.7'
 
 
 def test_borgmatic_installed(host):


### PR DESCRIPTION
The sks-keyservers pools are no longer maintained:
https://lists.gnupg.org/pipermail/gnupg-users/2021-June/065261.html